### PR TITLE
几个小fix和feature

### DIFF
--- a/src/main/kotlin/moe/ruabbit/mirai/KtorUtils.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/KtorUtils.kt
@@ -5,9 +5,17 @@ import io.ktor.client.engine.*
 import io.ktor.client.engine.okhttp.*
 import io.ktor.util.*
 import moe.ruabbit.mirai.config.SettingsConfig
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 
 @Suppress("EXPERIMENTAL_IS_NOT_ENABLED")
 object KtorUtils {
+
+    private val okHttpClient = OkHttpClient.Builder().apply {
+        retryOnConnectionFailure(true)
+        connectTimeout(30000L, TimeUnit.MILLISECONDS)
+    }
+
     // 使用代理的ktor客户端
     @OptIn(KtorExperimentalAPI::class)
     val proxyClient = HttpClient(OkHttp) {
@@ -18,11 +26,15 @@ object KtorUtils {
                 2 -> ProxyBuilder.socks(host = SettingsConfig.socksProxy.host, port = SettingsConfig.socksProxy.port)
                 else -> null
             }
+            config { okHttpClient }
         }
     }
 
     // 未使用代理的Ktor客户端
     val normalClient = HttpClient(OkHttp)
+    {
+        engine { config { okHttpClient } }
+    }
 
     // 安全的关闭客户端, 防止堵塞主线程
     fun closeClient() {

--- a/src/main/kotlin/moe/ruabbit/mirai/PluginMain.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/PluginMain.kt
@@ -7,6 +7,7 @@ import moe.ruabbit.mirai.KtorUtils.normalClient
 import moe.ruabbit.mirai.config.CommandConfig
 import moe.ruabbit.mirai.config.MessageConfig
 import moe.ruabbit.mirai.config.SettingsConfig
+import moe.ruabbit.mirai.config.registerConfigListener
 import moe.ruabbit.mirai.data.SetuData
 import moe.ruabbit.mirai.search.searchListenerRegister
 import moe.ruabbit.mirai.setu.setuListenerRegister
@@ -39,17 +40,14 @@ object PluginMain : KotlinPlugin(
             checkupdate()
         }
 
-        SettingsConfig.reload() //初始化设置数据
-        SetuData.reload()    //初始化配置数据
-        CommandConfig.reload()   //初始化插件指令
-        MessageConfig.reload()   //初始化自定义回复
+        reloadConfig()
         adminPermission = PermissionService.INSTANCE.register(
             PermissionId(name, "admin"),
             "管理员权限"
         )
         setuListenerRegister()
         searchListenerRegister()
-
+        registerConfigListener()
 
     }
 
@@ -57,6 +55,13 @@ object PluginMain : KotlinPlugin(
     override fun onDisable() {
         // 关闭ktor客户端, 防止堵塞线程无法关闭
         KtorUtils.closeClient()
+    }
+
+    fun reloadConfig() {
+        SettingsConfig.reload() //初始化设置数据
+        SetuData.reload()    //初始化配置数据
+        CommandConfig.reload()   //初始化插件指令
+        MessageConfig.reload()   //初始化自定义回复
     }
 
     // 权限判断（获取以后会搞上更好的方法？）

--- a/src/main/kotlin/moe/ruabbit/mirai/config/ConfigListener.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/config/ConfigListener.kt
@@ -1,0 +1,76 @@
+package moe.ruabbit.mirai.config
+
+import moe.ruabbit.mirai.PluginMain
+import moe.ruabbit.mirai.data.SetuData
+import net.mamoe.mirai.event.GlobalEventChannel
+import net.mamoe.mirai.event.subscribeGroupMessages
+
+
+fun registerConfigListener() {
+
+    GlobalEventChannel.subscribeGroupMessages {
+
+        // 重载配置
+        "mirai-setu reload"{
+            PluginMain.reloadConfig()
+            group.sendMessage(MessageConfig.setuConfigReloadComplete)
+        }
+
+        // 涩图插件开关控制
+        always {
+            // 关闭涩图插件
+            if (CommandConfig.off.contains(message.contentToString())) {
+                if (PluginMain.checkPermission(sender)) {
+                    if (SetuData.groupPolicy[group.id] == null) {
+                        group.sendMessage(MessageConfig.setuOffAlready)
+                    } else {
+                        group.sendMessage(MessageConfig.setuOff)
+                        SetuData.groupPolicy.remove(group.id)
+                    }
+                } else {
+                    group.sendMessage(MessageConfig.setuNoPermission)
+                }
+            }
+            // 设置为普通模式
+            if (CommandConfig.setSafeMode.contains(message.contentToString())) {
+                if (PluginMain.checkPermission(sender)) {
+                    if (SetuData.groupPolicy[group.id] == 0) {
+                        group.sendMessage(MessageConfig.setuSafeAlready)
+                    } else {
+                        group.sendMessage(MessageConfig.setuSafe)
+                        SetuData.groupPolicy[group.id] = 0
+                    }
+                } else {
+                    group.sendMessage(MessageConfig.setuNoPermission)
+                }
+            }
+            // 设置为R-19模式
+            if (CommandConfig.setNsfwMode.contains(message.contentToString())) {
+                if (PluginMain.checkPermission(sender)) {
+                    if (SetuData.groupPolicy[group.id] == 1) {
+                        group.sendMessage(MessageConfig.setuNsfwAlready)
+                    } else {
+                        group.sendMessage(MessageConfig.setuNsfw)
+                        SetuData.groupPolicy[group.id] = 1
+                    }
+                } else {
+                    group.sendMessage(MessageConfig.setuNoPermission)
+                }
+            }
+            // 设置为混合模式
+            if (CommandConfig.setBothMode.contains(message.contentToString())) {
+                if (PluginMain.checkPermission(sender)) {
+                    if (SetuData.groupPolicy[group.id] == 2) {
+                        group.sendMessage(MessageConfig.setuBothAlready)
+                    } else {
+                        group.sendMessage(MessageConfig.setuBoth)
+                        SetuData.groupPolicy[group.id] = 2
+                    }
+                } else {
+                    group.sendMessage(MessageConfig.setuNoPermission)
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/moe/ruabbit/mirai/config/MessageConfig.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/config/MessageConfig.kt
@@ -14,7 +14,7 @@ object MessageConfig : ReadOnlyPluginConfig("Message") {
         title           题目
         author          作者
         url             原始url
-        r18             是否为r18
+        r18             是否为r18(仅LoliconApi有效)
         width           宽度
         height          高度
         tags            标签
@@ -63,4 +63,10 @@ object MessageConfig : ReadOnlyPluginConfig("Message") {
     @ValueDescription("设置混合模式的自动回复")
     val setuBoth by value("切换为混合模式")
     val setuBothAlready by value("本群色图已经为混合模式, 无需切换")
+
+    @ValueDescription("色图冷却尚未完成时的提醒")
+    val setuCoolDownNotReady by value("别再冲了，歇息一会儿吧，剩余冷却%d秒")
+
+    @ValueDescription("配置重载时的提醒")
+    val setuConfigReloadComplete by value("配置重载完成")
 }

--- a/src/main/kotlin/moe/ruabbit/mirai/config/SettingsConfig.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/config/SettingsConfig.kt
@@ -1,6 +1,9 @@
 package moe.ruabbit.mirai.config
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import moe.ruabbit.mirai.setu.FantasyZoneRequester
+import moe.ruabbit.mirai.setu.LoliconRequester
 import net.mamoe.mirai.console.data.ReadOnlyPluginConfig
 import net.mamoe.mirai.console.data.ValueDescription
 import net.mamoe.mirai.console.data.value
@@ -27,7 +30,7 @@ object SettingsConfig : ReadOnlyPluginConfig("Settings") {
         LoliconApi      需要ApiKey        https://api.lolicon.app/#/setu
         """
     )
-    val requestApi by value("FantasyZoneApi")
+    val requestApi by value(FantasyZoneRequester.TAG)
 
     @ValueDescription(
         """
@@ -36,7 +39,7 @@ object SettingsConfig : ReadOnlyPluginConfig("Settings") {
         LoliconApi      需要ApiKey        https://api.lolicon.app/#/setu
         """
     )
-    val searchApi by value("LoliconApi")
+    val searchApi by value(LoliconRequester.TAG)
 
     @ValueDescription(
         """
@@ -69,10 +72,21 @@ object SettingsConfig : ReadOnlyPluginConfig("Settings") {
         0   不使用代理
         1   使用http代理
         2   使用socks代理
-        代理只对 LoliconApi 色图的获取生效
         """
     )
     val proxyConfig by value(0)
+
+    @ValueDescription("代理设置生效的API")
+    val effectApi by value(effectApiConfig())
+
+    @Serializable
+    data class effectApiConfig(
+        @SerialName("enable_FantasyZoneApi") val enableFantasyZone: Boolean = false,
+        @SerialName("enable_LoliconApi") val enableLolicon: Boolean = true
+    )
+
+
+
     val httpProxy by value(HttpProxy())
     val socksProxy by value(SocksProxy())
 

--- a/src/main/kotlin/moe/ruabbit/mirai/config/SettingsConfig.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/config/SettingsConfig.kt
@@ -117,4 +117,7 @@ object SettingsConfig : ReadOnlyPluginConfig("Settings") {
         """
     )
     val autoRecallTime: Long by value(-1L)
+
+
+    val enableFetchingMsg by value(true)
 }

--- a/src/main/kotlin/moe/ruabbit/mirai/config/SettingsConfig.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/config/SettingsConfig.kt
@@ -118,6 +118,14 @@ object SettingsConfig : ReadOnlyPluginConfig("Settings") {
     )
     val autoRecallTime: Long by value(-1L)
 
+    @ValueDescription(
+        """
+        设置群搜色图和随机色图的冷却时间
+        单位毫秒,-1为无冷却
+        当一张图片发送成功后进入cd
+        """
+    )
+    val coolDownTime: Long by value(-1L)
 
     val enableFetchingMsg by value(true)
 }

--- a/src/main/kotlin/moe/ruabbit/mirai/setu/FantasyZoneRequester.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/setu/FantasyZoneRequester.kt
@@ -18,16 +18,27 @@ import java.io.InputStream
 
 class FantasyZoneRequester(private val subject: Group, private val source: MessageSource) {
 
+    companion object {
+        const val TAG = "FantasyZoneApi"
+    }
+
     // 图片数据
     private lateinit var imageResponse: FantasyZoneResponse
+
+    private val httpClient by lazy {
+        if (SettingsConfig.proxyConfig != 0 && SettingsConfig.effectApi.enableFantasyZone) {
+            KtorUtils.proxyClient
+        } else {
+            KtorUtils.normalClient
+        }
+    }
 
     @Throws(Throwable::class)
     @KtorExperimentalAPI
     suspend fun requestSetu(): Boolean {
         try {
-            // TODO 增加不使用代理的配置
             imageResponse = Json { coerceInputValues = true }.decodeFromString(
-                KtorUtils.proxyClient.get(
+                httpClient.get(
                     "https://api.fantasyzone.cc/tu?type=json&class=${
                         SettingsConfig.fantasyZoneType.replace(
                             "random",
@@ -57,7 +68,7 @@ class FantasyZoneRequester(private val subject: Group, private val source: Messa
     suspend fun requestSetu(search: String): Boolean {
         try {
             val jsonResponse: String =
-                KtorUtils.proxyClient.get("https://api.fantasyzone.cc/tu/search.php?search=${search}")  //TODO 适配直接取图
+                httpClient.get("https://api.fantasyzone.cc/tu/search.php?search=${search}")  //TODO 适配直接取图
 
             imageResponse = Json {
                 coerceInputValues = true
@@ -123,6 +134,6 @@ class FantasyZoneRequester(private val subject: Group, private val source: Messa
     }
 
     @KtorExperimentalAPI
-    suspend fun getImage(): InputStream = KtorUtils.proxyClient.get(imageResponse.url)
+    suspend fun getImage(): InputStream = httpClient.get(imageResponse.url)
 
 }

--- a/src/main/kotlin/moe/ruabbit/mirai/setu/FantasyZoneRequester.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/setu/FantasyZoneRequester.kt
@@ -6,6 +6,7 @@ import io.ktor.util.*
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import moe.ruabbit.mirai.KtorUtils
+import moe.ruabbit.mirai.PluginMain
 import moe.ruabbit.mirai.config.MessageConfig
 import moe.ruabbit.mirai.config.SettingsConfig
 import moe.ruabbit.mirai.data.SetuData
@@ -36,6 +37,7 @@ class FantasyZoneRequester(private val subject: Group, private val source: Messa
     @Throws(Throwable::class)
     @KtorExperimentalAPI
     suspend fun requestSetu(): Boolean {
+        PluginMain.logger.info("fantasyZone r18=${SetuData.groupPolicy[subject.id]}")
         try {
             imageResponse = Json { coerceInputValues = true }.decodeFromString(
                 httpClient.get(
@@ -68,7 +70,7 @@ class FantasyZoneRequester(private val subject: Group, private val source: Messa
     suspend fun requestSetu(search: String): Boolean {
         try {
             val jsonResponse: String =
-                httpClient.get("https://api.fantasyzone.cc/tu/search.php?search=${search}")  //TODO 适配直接取图
+                httpClient.get("https://api.fantasyzone.cc/tu/search.php?search=${search}&r18=${SetuData.groupPolicy[subject.id]}")  //TODO 适配直接取图
 
             imageResponse = Json {
                 coerceInputValues = true
@@ -120,6 +122,7 @@ class FantasyZoneRequester(private val subject: Group, private val source: Messa
 
     // 解析字符串
     private fun parseMessage(message: String): String {
+        val r18judge = imageResponse.tags.toString().contains(Regex("[Rr].*18")).toString()
         return message
             .replace("%url%", imageResponse.url)
             .replace("%pid%", imageResponse.id)
@@ -128,6 +131,7 @@ class FantasyZoneRequester(private val subject: Group, private val source: Messa
             .replace("%author%", imageResponse.userName)
             .replace("%title%", imageResponse.title)
             .replace("%url%", imageResponse.toString())
+            .replace("%r18%", r18judge)
             .replace("%width%", imageResponse.width)
             .replace("%height%", imageResponse.height)
             .replace("%tags%", imageResponse.tags.toString())

--- a/src/main/kotlin/moe/ruabbit/mirai/setu/LoliconRequester.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/setu/LoliconRequester.kt
@@ -19,6 +19,19 @@ import net.mamoe.mirai.utils.error
 import java.io.InputStream
 
 class LoliconRequester(private val subject: Group, private val source: MessageSource) {
+
+    companion object {
+        const val TAG = "LoliconApi"
+    }
+
+    private val httpClient by lazy {
+        if (SettingsConfig.proxyConfig != 0 && SettingsConfig.effectApi.enableLolicon) {
+            KtorUtils.proxyClient
+        } else {
+            KtorUtils.normalClient
+        }
+    }
+
     // 图片数据
     private lateinit var imageResponse: LoliconResponse.SetuImageInfo
 
@@ -27,7 +40,7 @@ class LoliconRequester(private val subject: Group, private val source: MessageSo
     suspend fun requestSetu(): Boolean {
         try {
             val response: String =
-                KtorUtils.proxyClient.get(
+                httpClient.get(
                     "http://api.lolicon.app/setu?r18=${
                         SetuData.groupPolicy[subject.id]
                     }"
@@ -48,7 +61,7 @@ class LoliconRequester(private val subject: Group, private val source: MessageSo
     suspend fun requestSetu(keyword: String): Boolean {
         try {
             val setuResponse: String =
-                KtorUtils.proxyClient.get(
+                httpClient.get(
                     "http://api.lolicon.app/setu?keyword=${keyword}&r18=${
                         SetuData.groupPolicy[subject.id]
                     }"
@@ -109,7 +122,7 @@ class LoliconRequester(private val subject: Group, private val source: MessageSo
 
     @KtorExperimentalAPI
     suspend fun getImage(): InputStream =
-        KtorUtils.proxyClient.get(imageResponse.url.replace("i.pixiv.cat", SettingsConfig.domainProxy)) {
+        httpClient.get(imageResponse.url.replace("i.pixiv.cat", SettingsConfig.domainProxy)) {
             headers.append("referer", "https://www.pixiv.net/")
         }
 

--- a/src/main/kotlin/moe/ruabbit/mirai/setu/LoliconRequester.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/setu/LoliconRequester.kt
@@ -39,6 +39,7 @@ class LoliconRequester(private val subject: Group, private val source: MessageSo
     @KtorExperimentalAPI
     suspend fun requestSetu(): Boolean {
         try {
+            PluginMain.logger.info("lolicon r18=${SetuData.groupPolicy[subject.id]}")
             val response: String =
                 httpClient.get(
                     "http://api.lolicon.app/setu?r18=${

--- a/src/main/kotlin/moe/ruabbit/mirai/setu/SetuCoolDownManager.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/setu/SetuCoolDownManager.kt
@@ -1,0 +1,38 @@
+package moe.ruabbit.mirai.setu
+
+import moe.ruabbit.mirai.config.SettingsConfig
+import java.util.*
+
+object SetuCoolDownManager {
+
+    /**
+     * <群号,上次发送成功时间>
+     */
+    private val coolDownMap: MutableMap<Long, Date> by lazy {
+        mutableMapOf()
+    }
+
+    /**
+     * 是否冷却完成
+     * @return 剩余冷却时间 0代表冷却完成
+     */
+    fun isCoolDown(groupId: Long): Long {
+        val coolDownConfigMs = SettingsConfig.coolDownTime
+        if (coolDownConfigMs > 0) {
+            coolDownMap[groupId]?.let {
+                val now = Date()
+                return (coolDownConfigMs - (now.time - it.time)).coerceAtLeast(0) / 1000L
+            }
+        }
+        return 0
+    }
+
+    /**
+     * 发送成功 进入冷却计算
+     */
+    fun startCoolDown(groupId: Long) {
+        coolDownMap[groupId] = Date()
+    }
+
+
+}

--- a/src/main/kotlin/moe/ruabbit/mirai/setu/SetuListenser.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/setu/SetuListenser.kt
@@ -19,18 +19,32 @@ fun setuListenerRegister() {
         always {
             if (CommandConfig.get.contains(message.contentToString())) {
                 if (SetuData.groupPolicy[group.id] != null) {
+                    val coolDown = SetuCoolDownManager.isCoolDown(group.id)
+                    if (coolDown > 0) {
+                        group.sendMessage(message.quote() + String.format(MessageConfig.setuCoolDownNotReady, coolDown))
+                        return@always
+                    }
+
                     when (SettingsConfig.requestApi) {
                         FantasyZoneRequester.TAG -> {
                             val setu = FantasyZoneRequester(group, source)
-                            group.sendMessage(message.quote() + "Fetching setu...")
-                            if (setu.requestSetu())
+                            if (SettingsConfig.enableFetchingMsg) {
+                                group.sendMessage(message.quote() + "Fetching setu...")
+                            }
+                            if (setu.requestSetu()){
                                 setu.sendSetu()
+                                SetuCoolDownManager.startCoolDown(group.id)
+                            }
                         }
                         LoliconRequester.TAG -> {
                             val setu = LoliconRequester(group, source)
-                            group.sendMessage(message.quote() + "Fetching setu...")
-                            if (setu.requestSetu())
+                            if (SettingsConfig.enableFetchingMsg) {
+                                group.sendMessage(message.quote() + "Fetching setu...")
+                            }
+                            if (setu.requestSetu()){
                                 setu.sendSetu()
+                                SetuCoolDownManager.startCoolDown(group.id)
+                            }
                         }
                         else -> {
                             group.sendMessage(message.quote() + "requestApi 配置错误")
@@ -47,6 +61,11 @@ fun setuListenerRegister() {
             CommandConfig.search.startWith(message.contentToString()).let {
                 if (it != null) {
                     if (SetuData.groupPolicy[group.id] != null) {
+                        val coolDown = SetuCoolDownManager.isCoolDown(group.id)
+                        if (coolDown > 0) {
+                            group.sendMessage(message.quote() + String.format(MessageConfig.setuCoolDownNotReady, coolDown))
+                            return@always
+                        }
                         val msg = it.ifEmpty {
                             group.sendMessage(message.quote() + MessageConfig.setuSearchKeyNotSet)
                             nextMessage().contentToString()
@@ -54,15 +73,25 @@ fun setuListenerRegister() {
                         when (SettingsConfig.searchApi) {
                             FantasyZoneRequester.TAG -> {
                                 val setu = FantasyZoneRequester(group, source)
-                                group.sendMessage(message.quote() + "Fetching setu...")
-                                if (setu.requestSetu(msg))
+                                if (SettingsConfig.enableFetchingMsg) {
+                                    group.sendMessage(message.quote() + "Fetching setu...")
+                                }
+                                if (setu.requestSetu(msg)){
                                     setu.sendSetu()
+                                    SetuCoolDownManager.startCoolDown(group.id)
+                                }
+
                             }
                             LoliconRequester.TAG -> {
                                 val setu = LoliconRequester(group, source)
-                                group.sendMessage(message.quote() + "Fetching setu...")
-                                if (setu.requestSetu(msg))
+                                if (SettingsConfig.enableFetchingMsg) {
+                                    group.sendMessage(message.quote() + "Fetching setu...")
+                                }
+                                if (setu.requestSetu(msg)){
                                     setu.sendSetu()
+                                    SetuCoolDownManager.startCoolDown(group.id)
+                                }
+
                             }
                             else -> {
                                 group.sendMessage(message.quote() + "requestApi 配置错误")
@@ -71,62 +100,6 @@ fun setuListenerRegister() {
                     } else {
                         group.sendMessage(message.quote() + MessageConfig.setuModeOff)
                     }
-                }
-            }
-        }
-
-        // 涩图插件开关控制
-        always {
-            // 关闭涩图插件
-            if (CommandConfig.off.contains(message.contentToString())) {
-                if (checkPermission(sender)) {
-                    if (SetuData.groupPolicy[group.id] == null) {
-                        group.sendMessage(MessageConfig.setuOffAlready)
-                    } else {
-                        group.sendMessage(MessageConfig.setuOff)
-                        SetuData.groupPolicy.remove(group.id)
-                    }
-                } else {
-                    group.sendMessage(MessageConfig.setuNoPermission)
-                }
-            }
-            // 设置为普通模式
-            if (CommandConfig.setSafeMode.contains(message.contentToString())) {
-                if (checkPermission(sender)) {
-                    if (SetuData.groupPolicy[group.id] == 0) {
-                        group.sendMessage(MessageConfig.setuSafeAlready)
-                    } else {
-                        group.sendMessage(MessageConfig.setuSafe)
-                        SetuData.groupPolicy[group.id] = 0
-                    }
-                } else {
-                    group.sendMessage(MessageConfig.setuNoPermission)
-                }
-            }
-            // 设置为R-18模式
-            if (CommandConfig.setNsfwMode.contains(message.contentToString())) {
-                if (checkPermission(sender)) {
-                    if (SetuData.groupPolicy[group.id] == 1) {
-                        group.sendMessage(MessageConfig.setuNsfwAlready)
-                    } else {
-                        group.sendMessage(MessageConfig.setuNsfw)
-                        SetuData.groupPolicy[group.id] = 1
-                    }
-                } else {
-                    group.sendMessage(MessageConfig.setuNoPermission)
-                }
-            }
-            // 设置为混合模式
-            if (CommandConfig.setBothMode.contains(message.contentToString())) {
-                if (checkPermission(sender)) {
-                    if (SetuData.groupPolicy[group.id] == 2) {
-                        group.sendMessage(MessageConfig.setuBothAlready)
-                    } else {
-                        group.sendMessage(MessageConfig.setuBoth)
-                        SetuData.groupPolicy[group.id] = 2
-                    }
-                } else {
-                    group.sendMessage(MessageConfig.setuNoPermission)
                 }
             }
         }

--- a/src/main/kotlin/moe/ruabbit/mirai/setu/SetuListenser.kt
+++ b/src/main/kotlin/moe/ruabbit/mirai/setu/SetuListenser.kt
@@ -20,13 +20,13 @@ fun setuListenerRegister() {
             if (CommandConfig.get.contains(message.contentToString())) {
                 if (SetuData.groupPolicy[group.id] != null) {
                     when (SettingsConfig.requestApi) {
-                        "FantasyZoneApi" -> {
+                        FantasyZoneRequester.TAG -> {
                             val setu = FantasyZoneRequester(group, source)
                             group.sendMessage(message.quote() + "Fetching setu...")
                             if (setu.requestSetu())
                                 setu.sendSetu()
                         }
-                        "LoliconApi" -> {
+                        LoliconRequester.TAG -> {
                             val setu = LoliconRequester(group, source)
                             group.sendMessage(message.quote() + "Fetching setu...")
                             if (setu.requestSetu())
@@ -52,13 +52,13 @@ fun setuListenerRegister() {
                             nextMessage().contentToString()
                         }
                         when (SettingsConfig.searchApi) {
-                            "FantasyZoneApi" -> {
+                            FantasyZoneRequester.TAG -> {
                                 val setu = FantasyZoneRequester(group, source)
                                 group.sendMessage(message.quote() + "Fetching setu...")
                                 if (setu.requestSetu(msg))
                                     setu.sendSetu()
                             }
-                            "LoliconApi" -> {
+                            LoliconRequester.TAG -> {
                                 val setu = LoliconRequester(group, source)
                                 group.sendMessage(message.quote() + "Fetching setu...")
                                 if (setu.requestSetu(msg))


### PR DESCRIPTION
fix:修复了代理对不同api的影响 改为单独控制 此问题曾导致配置代理的情况下FantasyZoneApi不可用
fix:修复R-18参数传递错误导致各个模式控制无效
opt:FantasyZoneApi中返回内容通过tag判断是否r18 补全到输出中
feat:fetching消息开关
feat:可配置冷却时间
feat:允许通过聊天消息触发配置重载